### PR TITLE
Add sensor readings data fetching utilities

### DIFF
--- a/hooks/use-sensor-readings.ts
+++ b/hooks/use-sensor-readings.ts
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  fetchSensorReadings,
+  type PaginationMeta,
+  type SensorReading,
+  type SensorReadingsResponse,
+} from "@/lib/api/sensor-readings";
+
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+
+type FetchRequest = {
+  page: number;
+  limit: number;
+  withLoading: boolean;
+};
+
+const sanitizePositiveInteger = (
+  value: number,
+  fallback: number,
+  { allowZero = false }: { allowZero?: boolean } = {},
+) => {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const normalized = Math.floor(value);
+
+  if (allowZero) {
+    return normalized < 0 ? fallback : normalized;
+  }
+
+  return normalized <= 0 ? fallback : normalized;
+};
+
+export interface UseSensorReadingsOptions {
+  /** Page number to request initially. */
+  initialPage?: number;
+  /** Page size to request initially. */
+  initialLimit?: number;
+  /** How frequently to poll for fresh data (ms). */
+  pollIntervalMs?: number;
+  /** Disable fetching/polling when false. */
+  enabled?: boolean;
+}
+
+export interface UseSensorReadingsResult {
+  data: SensorReading[];
+  meta: PaginationMeta | null;
+  page: number;
+  limit: number;
+  isLoading: boolean;
+  isRefreshing: boolean;
+  error: Error | null;
+  setPage: (value: number | ((current: number) => number)) => void;
+  setLimit: (value: number | ((current: number) => number)) => void;
+  refetch: () => Promise<SensorReadingsResponse | null>;
+}
+
+export function useSensorReadings({
+  initialPage = 1,
+  initialLimit = 20,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  enabled = true,
+}: UseSensorReadingsOptions = {}): UseSensorReadingsResult {
+  const [page, setPageState] = useState(() =>
+    sanitizePositiveInteger(initialPage, 1, { allowZero: true }),
+  );
+  const [limit, setLimitState] = useState(() =>
+    sanitizePositiveInteger(initialLimit, 20),
+  );
+  const [data, setData] = useState<SensorReading[]>([]);
+  const [meta, setMeta] = useState<PaginationMeta | null>(null);
+  const [isLoading, setIsLoading] = useState(() => Boolean(enabled));
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const controllerRef = useRef<AbortController | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const fetchData = useCallback(
+    async ({ page: nextPage, limit: nextLimit, withLoading }: FetchRequest) => {
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      if (withLoading) {
+        setIsLoading(true);
+      } else {
+        setIsRefreshing(true);
+      }
+
+      try {
+        const response = await fetchSensorReadings({
+          page: nextPage,
+          limit: nextLimit,
+          signal: controller.signal,
+        });
+
+        if (controller.signal.aborted || controllerRef.current !== controller) {
+          return null;
+        }
+
+        setData(response.data);
+        setMeta(response.meta);
+        setError(null);
+
+        return response;
+      } catch (caughtError) {
+        if ((caughtError as Error).name === "AbortError") {
+          return null;
+        }
+
+        setError(caughtError as Error);
+        return null;
+      } finally {
+        const isLatestRequest = controllerRef.current === controller;
+
+        if (withLoading) {
+          if (isLatestRequest) {
+            setIsLoading(false);
+          }
+        } else if (isLatestRequest) {
+          setIsRefreshing(false);
+        } else {
+          setIsRefreshing(false);
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      controllerRef.current?.abort();
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      setIsLoading(false);
+      setIsRefreshing(false);
+      return;
+    }
+
+    fetchData({ page, limit, withLoading: true });
+  }, [enabled, page, limit, fetchData]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (pollIntervalMs <= 0) {
+      return;
+    }
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+
+    intervalRef.current = setInterval(() => {
+      fetchData({ page, limit, withLoading: false });
+    }, pollIntervalMs);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [enabled, page, limit, pollIntervalMs, fetchData]);
+
+  const setPage = useCallback(
+    (value: number | ((current: number) => number)) => {
+      setPageState((current) => {
+        const nextValue =
+          typeof value === "function" ? (value as (c: number) => number)(current) : value;
+
+        return sanitizePositiveInteger(nextValue, 1, { allowZero: true });
+      });
+    },
+    [],
+  );
+
+  const setLimit = useCallback(
+    (value: number | ((current: number) => number)) => {
+      setLimitState((current) => {
+        const nextValue =
+          typeof value === "function" ? (value as (c: number) => number)(current) : value;
+
+        return sanitizePositiveInteger(nextValue, 20);
+      });
+    },
+    [],
+  );
+
+  const refetch = useCallback(() => fetchData({ page, limit, withLoading: false }), [
+    fetchData,
+    page,
+    limit,
+  ]);
+
+  return useMemo(
+    () => ({
+      data,
+      meta,
+      page,
+      limit,
+      isLoading,
+      isRefreshing,
+      error,
+      setPage,
+      setLimit,
+      refetch,
+    }),
+    [data, meta, page, limit, isLoading, isRefreshing, error, setPage, setLimit, refetch],
+  );
+}

--- a/lib/api/sensor-readings.ts
+++ b/lib/api/sensor-readings.ts
@@ -1,0 +1,65 @@
+export const SENSOR_READINGS_ENDPOINT =
+  process.env.NEXT_PUBLIC_SENSOR_READINGS_ENDPOINT ??
+  "http://localhost:8080/api/sensor-readings-alt";
+
+export interface SensorReading {
+  timestamp: string;
+  moisture: number;
+}
+
+export interface PaginationMeta {
+  totalItems: number;
+  totalPages: number;
+  page: number;
+  limit: number;
+}
+
+export interface SensorReadingsResponse {
+  data: SensorReading[];
+  meta: PaginationMeta;
+}
+
+export interface FetchSensorReadingsParams {
+  page?: number;
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+export async function fetchSensorReadings({
+  page = 1,
+  limit = 20,
+  signal,
+}: FetchSensorReadingsParams = {}): Promise<SensorReadingsResponse> {
+  const url = new URL(SENSOR_READINGS_ENDPOINT);
+
+  if (typeof page === "number" && !Number.isNaN(page)) {
+    url.searchParams.set("page", String(page));
+  }
+
+  if (typeof limit === "number" && !Number.isNaN(limit)) {
+    url.searchParams.set("limit", String(limit));
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+    signal,
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch sensor readings: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const payload = (await response.json()) as SensorReadingsResponse;
+
+  if (!payload || !Array.isArray(payload.data) || typeof payload.meta !== "object") {
+    throw new Error("Invalid sensor readings response shape");
+  }
+
+  return payload;
+}


### PR DESCRIPTION
## Summary
- add reusable API helper for fetching sensor reading data with pagination metadata
- introduce `useSensorReadings` hook that handles polling, pagination state, and error management

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd331c1dac8320b56ffd67581948fe