### PR TITLE
Add sensor readings table configuration

### DIFF
--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import {
+  flexRender,
+  getCoreRowModel,
+  type ColumnDef,
+  type ColumnFiltersState,
+  type Row,
+  type SortingState,
+  type TableOptions,
+  type VisibilityState,
+  useReactTable,
+} from "@tanstack/react-table";
+import * as React from "react";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export interface DataTableState {
+  sorting?: SortingState;
+  columnFilters?: ColumnFiltersState;
+  columnVisibility?: VisibilityState;
+}
+
+export interface DataTableProps<TData, TValue>
+  extends Pick<
+      TableOptions<TData>,
+      "data" | "getRowId" | "getSubRows" | "manualPagination" | "pageCount"
+    >,
+    DataTableState {
+  columns: ColumnDef<TData, TValue>[];
+  emptyState?: React.ReactNode;
+  isLoading?: boolean;
+  onSortingChange?: (sorting: SortingState) => void;
+  onColumnFiltersChange?: (filters: ColumnFiltersState) => void;
+  onColumnVisibilityChange?: (visibility: VisibilityState) => void;
+  renderSubComponent?: (props: { row: Row<TData> }) => React.ReactNode;
+}
+
+const defaultEmptyState = (
+  <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+    No results.
+  </div>
+);
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  pageCount,
+  manualPagination,
+  getRowId,
+  getSubRows,
+  renderSubComponent,
+  emptyState = defaultEmptyState,
+  isLoading = false,
+  sorting,
+  columnFilters,
+  columnVisibility,
+  onSortingChange,
+  onColumnFiltersChange,
+  onColumnVisibilityChange,
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    pageCount,
+    manualPagination,
+    getRowId,
+    getSubRows,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+    },
+    onSortingChange,
+    onColumnFiltersChange,
+    onColumnVisibilityChange,
+  });
+
+  const isEmpty = !isLoading && table.getRowModel().rows.length === 0;
+
+  return (
+    <div className="space-y-2">
+      <div className="overflow-hidden rounded-lg border bg-background">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  Loading sensor readings...
+                </TableCell>
+              </TableRow>
+            ) : isEmpty ? (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="p-0">
+                  {emptyState}
+                </TableCell>
+              </TableRow>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <React.Fragment key={row.id}>
+                  <TableRow data-state={row.getIsSelected() ? "selected" : undefined}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                  {renderSubComponent && row.getIsExpanded() ? (
+                    <TableRow>
+                      <TableCell colSpan={columns.length}>
+                        {renderSubComponent({ row })}
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </React.Fragment>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/components/sensor-readings/columns.tsx
+++ b/components/sensor-readings/columns.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { type ColumnDef } from "@tanstack/react-table";
+
+import { type SensorReading } from "@/lib/api/sensor-readings";
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+function formatTimestamp(value: string) {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return dateTimeFormatter.format(parsed);
+}
+
+export const sensorReadingColumns: ColumnDef<SensorReading>[] = [
+  {
+    accessorKey: "timestamp",
+    header: "Timestamp",
+    cell: ({ row }) => {
+      const timestamp = row.getValue<string>("timestamp");
+      return <span className="font-medium text-foreground">{formatTimestamp(timestamp)}</span>;
+    },
+  },
+  {
+    accessorKey: "moisture",
+    header: "Moisture",
+    cell: ({ row }) => {
+      const moisture = row.getValue<number>("moisture");
+      if (typeof moisture !== "number" || Number.isNaN(moisture)) {
+        return <span className="text-muted-foreground">—</span>;
+      }
+
+      return <span className="tabular-nums text-foreground">{moisture}</span>;
+    },
+  },
+];

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className,
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className,
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0",
+      className,
+    )}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/hooks/use-sensor-readings.ts
+++ b/hooks/use-sensor-readings.ts
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  fetchSensorReadings,
+  type PaginationMeta,
+  type SensorReading,
+  type SensorReadingsResponse,
+} from "@/lib/api/sensor-readings";
+
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+
+type FetchRequest = {
+  page: number;
+  limit: number;
+  withLoading: boolean;
+};
+
+const sanitizePositiveInteger = (
+  value: number,
+  fallback: number,
+  { allowZero = false }: { allowZero?: boolean } = {},
+) => {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const normalized = Math.floor(value);
+
+  if (allowZero) {
+    return normalized < 0 ? fallback : normalized;
+  }
+
+  return normalized <= 0 ? fallback : normalized;
+};
+
+export interface UseSensorReadingsOptions {
+  /** Page number to request initially. */
+  initialPage?: number;
+  /** Page size to request initially. */
+  initialLimit?: number;
+  /** How frequently to poll for fresh data (ms). */
+  pollIntervalMs?: number;
+  /** Disable fetching/polling when false. */
+  enabled?: boolean;
+}
+
+export interface UseSensorReadingsResult {
+  data: SensorReading[];
+  meta: PaginationMeta | null;
+  page: number;
+  limit: number;
+  isLoading: boolean;
+  isRefreshing: boolean;
+  error: Error | null;
+  setPage: (value: number | ((current: number) => number)) => void;
+  setLimit: (value: number | ((current: number) => number)) => void;
+  refetch: () => Promise<SensorReadingsResponse | null>;
+}
+
+export function useSensorReadings({
+  initialPage = 1,
+  initialLimit = 20,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  enabled = true,
+}: UseSensorReadingsOptions = {}): UseSensorReadingsResult {
+  const [page, setPageState] = useState(() =>
+    sanitizePositiveInteger(initialPage, 1, { allowZero: true }),
+  );
+  const [limit, setLimitState] = useState(() =>
+    sanitizePositiveInteger(initialLimit, 20),
+  );
+  const [data, setData] = useState<SensorReading[]>([]);
+  const [meta, setMeta] = useState<PaginationMeta | null>(null);
+  const [isLoading, setIsLoading] = useState(() => Boolean(enabled));
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const controllerRef = useRef<AbortController | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const fetchData = useCallback(
+    async ({ page: nextPage, limit: nextLimit, withLoading }: FetchRequest) => {
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      if (withLoading) {
+        setIsLoading(true);
+      } else {
+        setIsRefreshing(true);
+      }
+
+      try {
+        const response = await fetchSensorReadings({
+          page: nextPage,
+          limit: nextLimit,
+          signal: controller.signal,
+        });
+
+        if (controller.signal.aborted || controllerRef.current !== controller) {
+          return null;
+        }
+
+        setData(response.data);
+        setMeta(response.meta);
+        setError(null);
+
+        return response;
+      } catch (caughtError) {
+        if ((caughtError as Error).name === "AbortError") {
+          return null;
+        }
+
+        setError(caughtError as Error);
+        return null;
+      } finally {
+        const isLatestRequest = controllerRef.current === controller;
+
+        if (withLoading) {
+          if (isLatestRequest) {
+            setIsLoading(false);
+          }
+        } else if (isLatestRequest) {
+          setIsRefreshing(false);
+        } else {
+          setIsRefreshing(false);
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      controllerRef.current?.abort();
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      setIsLoading(false);
+      setIsRefreshing(false);
+      return;
+    }
+
+    fetchData({ page, limit, withLoading: true });
+  }, [enabled, page, limit, fetchData]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (pollIntervalMs <= 0) {
+      return;
+    }
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+
+    intervalRef.current = setInterval(() => {
+      fetchData({ page, limit, withLoading: false });
+    }, pollIntervalMs);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [enabled, page, limit, pollIntervalMs, fetchData]);
+
+  const setPage = useCallback(
+    (value: number | ((current: number) => number)) => {
+      setPageState((current) => {
+        const nextValue =
+          typeof value === "function" ? (value as (c: number) => number)(current) : value;
+
+        return sanitizePositiveInteger(nextValue, 1, { allowZero: true });
+      });
+    },
+    [],
+  );
+
+  const setLimit = useCallback(
+    (value: number | ((current: number) => number)) => {
+      setLimitState((current) => {
+        const nextValue =
+          typeof value === "function" ? (value as (c: number) => number)(current) : value;
+
+        return sanitizePositiveInteger(nextValue, 20);
+      });
+    },
+    [],
+  );
+
+  const refetch = useCallback(() => fetchData({ page, limit, withLoading: false }), [
+    fetchData,
+    page,
+    limit,
+  ]);
+
+  return useMemo(
+    () => ({
+      data,
+      meta,
+      page,
+      limit,
+      isLoading,
+      isRefreshing,
+      error,
+      setPage,
+      setLimit,
+      refetch,
+    }),
+    [data, meta, page, limit, isLoading, isRefreshing, error, setPage, setLimit, refetch],
+  );
+}

--- a/lib/api/sensor-readings.ts
+++ b/lib/api/sensor-readings.ts
@@ -1,0 +1,65 @@
+export const SENSOR_READINGS_ENDPOINT =
+  process.env.NEXT_PUBLIC_SENSOR_READINGS_ENDPOINT ??
+  "http://localhost:8080/api/sensor-readings-alt";
+
+export interface SensorReading {
+  timestamp: string;
+  moisture: number;
+}
+
+export interface PaginationMeta {
+  totalItems: number;
+  totalPages: number;
+  page: number;
+  limit: number;
+}
+
+export interface SensorReadingsResponse {
+  data: SensorReading[];
+  meta: PaginationMeta;
+}
+
+export interface FetchSensorReadingsParams {
+  page?: number;
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+export async function fetchSensorReadings({
+  page = 1,
+  limit = 20,
+  signal,
+}: FetchSensorReadingsParams = {}): Promise<SensorReadingsResponse> {
+  const url = new URL(SENSOR_READINGS_ENDPOINT);
+
+  if (typeof page === "number" && !Number.isNaN(page)) {
+    url.searchParams.set("page", String(page));
+  }
+
+  if (typeof limit === "number" && !Number.isNaN(limit)) {
+    url.searchParams.set("limit", String(limit));
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+    signal,
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch sensor readings: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const payload = (await response.json()) as SensorReadingsResponse;
+
+  if (!payload || !Array.isArray(payload.data) || typeof payload.meta !== "object") {
+    throw new Error("Invalid sensor readings response shape");
+  }
+
+  return payload;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,14 @@
       "name": "karsu-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.0.2",
+        "@tanstack/react-table": "^8.19.6",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.1",
         "next": "15.5.3",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "tailwind-merge": "^2.5.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -959,6 +964,39 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1258,6 +1296,39 @@
         "tailwindcss": "4.1.13"
       }
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1304,7 +1375,7 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2301,11 +2372,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2353,7 +2445,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5655,6 +5747,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,14 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.0.2",
+    "@tanstack/react-table": "^8.19.6",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "next": "15.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.3"
+    "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- add `@tanstack/react-table` and supporting utilities for shadcn data table usage
- introduce shadcn table primitives and a reusable generic `DataTable` component
- define sensor reading column configuration with timestamp formatting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd331c1dac8320b56ffd67581948fe